### PR TITLE
Add authoring functions to posts & Jekyll directly

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,6 +5,13 @@ layout: default
 <article class="post">
   <h1 class="post-title">{{ page.title }}</h1>
   <time datetime="{{ page.date | date_to_xmlschema }}" class="post-date">{{ page.date | date_to_string }}</time>
+  {% assign author = site.data.authors[page.author] %}
+{% if author %}
+    <span>
+        <!-- Personal Info. -->
+        Written by <a href="{{ author.web }}">{{ author.name }}</a>
+    </span>
+{% endif %}
   {{ content }}
 </article>
 

--- a/_posts/2022-11-21-welcome-to-blonger.md
+++ b/_posts/2022-11-21-welcome-to-blonger.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: Welcome to Blo(n)g(er)
+author: slade_rice_watkins
 ---
 
 Welcome to Blo(n)g(er). This is the my anti-blog, wherein if I post something on social media that requires an unrestricted character limit, I will post it here and link to it as a post.


### PR DESCRIPTION
Based upon: https://blog.sorryapp.com/blogging-with-jekyll/2014/02/06/adding-authors-to-your-jekyll-site.html

Futureproofing Blo(n)g(er) for multi-author support.